### PR TITLE
Add demo workflows for stickydisk usage and deletion

### DIFF
--- a/.github/workflows/demo-docker.yaml
+++ b/.github/workflows/demo-docker.yaml
@@ -42,7 +42,10 @@ jobs:
       - name: Verify Docker Build
         run: |
           echo "Docker image built successfully."
-          docker images | grep stickydisk-delete
+          docker images
+          echo ""
+          echo "Looking for stickydisk-delete image:"
+          docker images | grep stickydisk-delete || echo "Image may have been built with a different tag"
 
       - name: Delete Docker Build Cache
         uses: useblacksmith/stickydisk-delete@main

--- a/.github/workflows/demo-docker.yaml
+++ b/.github/workflows/demo-docker.yaml
@@ -19,25 +19,15 @@ jobs:
       - name: Create Sample Dockerfile
         run: |
           cat > Dockerfile << 'EOF'
-          FROM node:20-alpine
-          WORKDIR /app
+          FROM alpine:latest
 
-          # Install dependencies.
-          RUN apk add --no-cache git
+          # Create a simple hello world script.
+          RUN echo '#!/bin/sh' > /hello.sh && \
+              echo 'echo "Hello from Stickydisk Demo!"' >> /hello.sh && \
+              echo 'echo "This demonstrates Docker build cache management."' >> /hello.sh && \
+              chmod +x /hello.sh
 
-          # Copy package files.
-          COPY package.json pnpm-lock.yaml ./
-
-          # Install pnpm and dependencies.
-          RUN npm install -g pnpm && pnpm install --frozen-lockfile
-
-          # Copy source code.
-          COPY . .
-
-          # Build the application.
-          RUN pnpm build
-
-          CMD ["node", "dist/main.bundle.mjs"]
+          CMD ["/hello.sh"]
           EOF
 
       - name: Build Docker Image with Cache

--- a/.github/workflows/demo-docker.yaml
+++ b/.github/workflows/demo-docker.yaml
@@ -1,6 +1,7 @@
 name: Demo Docker Cache with Stickydisk
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches: [main]
 

--- a/.github/workflows/demo-docker.yaml
+++ b/.github/workflows/demo-docker.yaml
@@ -1,0 +1,64 @@
+name: Demo Docker Cache with Stickydisk
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  demo-docker-cache:
+    name: Demo Docker Build Cache with Deletion
+    runs-on: blacksmith-staging
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Builder
+        uses: useblacksmith/setup-docker-builder@v1
+
+      - name: Create Sample Dockerfile
+        run: |
+          cat > Dockerfile << 'EOF'
+          FROM node:20-alpine
+          WORKDIR /app
+
+          # Install dependencies.
+          RUN apk add --no-cache git
+
+          # Copy package files.
+          COPY package.json pnpm-lock.yaml ./
+
+          # Install pnpm and dependencies.
+          RUN npm install -g pnpm && pnpm install --frozen-lockfile
+
+          # Copy source code.
+          COPY . .
+
+          # Build the application.
+          RUN pnpm build
+
+          CMD ["node", "dist/main.bundle.mjs"]
+          EOF
+
+      - name: Build Docker Image with Cache
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: stickydisk-delete:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify Docker Build
+        run: |
+          echo "Docker image built successfully."
+          docker images | grep stickydisk-delete
+
+      - name: Delete Docker Build Cache
+        uses: useblacksmith/stickydisk-delete@v1
+        with:
+          delete-docker-cache: true
+
+      - name: Verify Cache Deletion
+        run: |
+          echo "Docker build cache for ${{ github.repository }} has been deleted."
+          echo "The next build will not benefit from cached layers."

--- a/.github/workflows/demo-docker.yaml
+++ b/.github/workflows/demo-docker.yaml
@@ -55,7 +55,7 @@ jobs:
           docker images | grep stickydisk-delete
 
       - name: Delete Docker Build Cache
-        uses: useblacksmith/stickydisk-delete@v1
+        uses: useblacksmith/stickydisk-delete@main
         with:
           delete-docker-cache: true
 

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -44,7 +44,7 @@ jobs:
           find ./demo-cache -type f | wc -l
 
       - name: Delete Stickydisk
-        uses: useblacksmith/stickydisk-delete@v1
+        uses: useblacksmith/stickydisk-delete@main
         with:
           delete-key: ${{ github.repository }}-demo-cache
 

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -1,0 +1,54 @@
+name: Demo Stickydisk Usage and Deletion
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  demo-stickydisk:
+    name: Demo Stickydisk with Deletion
+    runs-on: blacksmith-staging
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Mount Stickydisk
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-demo-cache
+          path: ./demo-cache
+
+      - name: Write Data to Stickydisk
+        run: |
+          echo "Creating demo files in stickydisk..."
+          mkdir -p ./demo-cache/data
+          echo "Hello from stickydisk!" > ./demo-cache/data/test.txt
+          echo "Timestamp: $(date)" >> ./demo-cache/data/test.txt
+          echo "Workflow run: ${{ github.run_number }}" >> ./demo-cache/data/test.txt
+
+          # Create some additional files.
+          for i in {1..5}; do
+            echo "Sample data file $i" > ./demo-cache/data/file$i.txt
+          done
+
+          echo "Files created in stickydisk:"
+          ls -lah ./demo-cache/data/
+
+      - name: Read Data from Stickydisk
+        run: |
+          echo "Reading data from stickydisk..."
+          cat ./demo-cache/data/test.txt
+          echo ""
+          echo "Total files in cache:"
+          find ./demo-cache -type f | wc -l
+
+      - name: Delete Stickydisk
+        uses: useblacksmith/stickydisk-delete@v1
+        with:
+          delete-key: ${{ github.repository }}-demo-cache
+
+      - name: Verify Deletion
+        run: |
+          echo "Stickydisk with key '${{ github.repository }}-demo-cache' has been deleted."
+          echo "This cache will not persist to the next workflow run."


### PR DESCRIPTION
- Add demo.yaml: demonstrates basic stickydisk lifecycle (create, use, delete)
- Add demo-docker.yaml: demonstrates Docker build cache with stickydisk deletion
- Both workflows run on blacksmith-staging runner
- Showcases useblacksmith/stickydisk@v1 and stickydisk-delete@v1 actions